### PR TITLE
[Feature] [WIP] Patch system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ cloud/cloud.json
 *.pyc
 *.zip
 pcap/pcap/
+bin/

--- a/infra/monolith.py
+++ b/infra/monolith.py
@@ -9,6 +9,7 @@ from utils import utils
 from infra.clientmanager import ClientManager
 from infra.connection import Connection
 from infra.chatcommands import ChatCommands
+from infra.patch import PatchManager
 from crypto.rsa import RSA
 from utils.rtbufferdeframer import RtBufferDeframer
 
@@ -22,6 +23,7 @@ class Monolith:
 		self._client_manager = ClientManager()
 		self._chat_commands = ChatCommands()
 		self._logger = logging.getLogger('robo.monolith')
+		self._patch_manager = PatchManager()
 
 
 	#################################################################################
@@ -196,6 +198,9 @@ class Monolith:
 
 	def process_chat(self, player, text):
 		self._chat_commands.process_chat(player, text)
+
+	def process_login(self, player):
+		self._patch_manager.process_login(player)
 
 # ===================================
 # API methods

--- a/infra/patch.py
+++ b/infra/patch.py
@@ -1,0 +1,110 @@
+from utils import utils
+from enums.enums import MediusEnum, RtIdEnum, MediusChatMessageType
+from medius.rtpackets.servermemorypoke import ServerMemoryPokeSerializer
+
+import logging
+logger = logging.getLogger('robo.patch')
+
+class PatchManager:
+	def __init__(self):
+		pass
+
+	def process_login(self, player):
+		self._send_patch(player)
+
+
+	def _send_patch(self, player, patch):
+		try:
+			# Send the player a whisper
+			packet = ServerMemoryPokeSerializer.build(0x000D0000, utils.bytes_from_hex("12345678"))
+			packet = utils.rtpacket_to_bytes(packet)
+			player.send_mls(packet)
+			logger.debug('sent patch to {0}'.format(player))
+
+		except:
+			logger.exception('error')
+
+
+# 
+class Patch:
+
+    ApplicationId = -1
+    PayloadPath = ""
+    Address = 0x0
+    UnhookPayloadPath = ""
+    UnhookAddress = 0x0
+    Hook = 0x0
+    HookType = ""
+
+    def __init__(self, appId, payloadPath, address, unhookPayloadPath, unhookAddress, hook, hookType):
+        self.ApplicationId = appId
+        self.PayloadPath = payloadPath
+        self.Address = address
+        self.UnhookPayloadPath = unhookPayloadPath
+        self.UnhookAddress = unhookAddress
+        self.Hook = hook
+        self.HookType = hookType
+    
+    # 
+    def send(self, player):
+        try:
+            # reset hook
+            if self.Hook > 0 and self.HookType == "j":
+                packet = ServerMemoryPokeSerializer.build(self.Hook, utils.bytes_from_hex("03E00008"))
+                packet = utils.rtpacket_to_bytes(packet)
+                player.send_mls(packet)
+
+            # send unpatch first
+            if self.UnhookPayloadPath != "":
+                self.sendFile(player, self.UnhookPayloadPath, self.UnhookAddress, True)
+
+
+            # send patch last
+            if self.PayloadPath != "":
+                self.sendFile(player, self.PayloadPath, self.Address, True)
+			
+            logger.debug('sent patch to {0}'.format(player))
+
+        except:
+            logger.exception('error')
+
+    # 
+    def sendFile(self, player, path, address, hook):
+
+        # determine hook
+        hookValue = address / 4
+        if self.HookType == "j":
+            hookValue |= 0x08000000
+        elif self.HookType == "jal":
+            hookValue |= 0x0C000000
+        else:
+            hookValue = 0
+
+        # load payload file
+        in_file = open(path, "rb")
+        data = in_file.read()
+        in_file.close()
+
+        # generate messages 
+        packet = ServerMemoryPokeSerializer.build(address, data)
+        packet = utils.rtpacket_to_bytes(packet)
+        player.send_mls(packet)
+
+        # send hook
+        if hook and hookValue > 0 and self.Hook > 0:
+            packet = ServerMemoryPokeSerializer.build(self.Hook, utils.int_to_bytes_little(4, hookValue))
+            packet = utils.rtpacket_to_bytes(packet)
+            player.send_mls(packet)
+
+    # send patch to client
+    def apply(self, player):
+        return self.send(player)
+
+
+# patch collection by app id
+Patches = {
+    11184: Patch(11184, 
+        "./bin/patch-ntsc.bin", 0x000D0000, 
+        "./bin/unpatch-ntsc.bin", 0x000E0000,
+        0, "j")
+}

--- a/infra/patch.py
+++ b/infra/patch.py
@@ -10,20 +10,9 @@ class PatchManager:
 		pass
 
 	def process_login(self, player):
-		self._send_patch(player)
-
-
-	def _send_patch(self, player, patch):
-		try:
-			# Send the player a whisper
-			packet = ServerMemoryPokeSerializer.build(0x000D0000, utils.bytes_from_hex("12345678"))
-			packet = utils.rtpacket_to_bytes(packet)
-			player.send_mls(packet)
-			logger.debug('sent patch to {0}'.format(player))
-
-		except:
-			logger.exception('error')
-
+		patch = Patches.get(10684)
+		if patch is not None:
+			patch.send(player)
 
 # 
 class Patch:
@@ -72,7 +61,7 @@ class Patch:
     def sendFile(self, player, path, address, hook):
 
         # determine hook
-        hookValue = address / 4
+        hookValue = int(address / 4)
         if self.HookType == "j":
             hookValue |= 0x08000000
         elif self.HookType == "jal":
@@ -103,7 +92,7 @@ class Patch:
 
 # patch collection by app id
 Patches = {
-    11184: Patch(11184, 
+    10684: Patch(10684, 
         "./bin/patch-ntsc.bin", 0x000D0000, 
         "./bin/unpatch-ntsc.bin", 0x000E0000,
         0, "j")

--- a/medius/mediuspackets/getallannouncements.py
+++ b/medius/mediuspackets/getallannouncements.py
@@ -12,6 +12,11 @@ class GetAllAnnouncementsSerializer:
 
 class GetAllAnnouncementsHandler:
 	def process(self, serialized, monolith, con):
+		# 
+		player = monolith.get_client_manager().get_player_from_mls_con(con)
+		if player is not None:
+			monolith.process_login(player)
+
 		return [GetAnnouncementsResponseSerializer.build(
 			serialized['message_id'],
 			CallbackStatus.SUCCESS,

--- a/medius/rtpackets/servermemorypoke.py
+++ b/medius/rtpackets/servermemorypoke.py
@@ -1,4 +1,4 @@
-
+from enums.enums import RtIdEnum
 from utils import utils
 
 class ServerMemoryPokeSerializer:
@@ -10,6 +10,17 @@ class ServerMemoryPokeSerializer:
 	def serialize(self, data: bytes):
 		raise Exception('Unimplemented Handler: ServerMemoryPokeSerializer')
 		return utils.serialize(data, self.data_dict)
+
+	@classmethod
+	def build(self, address: int, payload: bytes):
+		packet = [
+			{'name': __name__},
+			{'rtid': RtIdEnum.SERVER_MEMORY_POKE},
+			{'address': utils.int_to_bytes_little(4, address)},
+			{'count': utils.int_to_bytes_little(4, len(payload))},
+			{'payload': payload}
+		]
+		return packet
 
 class ServerMemoryPokeHandler:
 	def process(self, serialized, monolith, con):


### PR DESCRIPTION
This PR adds patch support to the server. Triggered when the player successfully logs in and pulls the announcements list, the server will send a configured patch payload based on the app id of the client (PAL/NTSC). 

Patch binaries should be placed in the bin folder located at the root of the robo directory. I use a symlink in my local environment that points to the bin folder in the uya-patch repo (www.github.com/dnawrkshp/uya-patch).


This is still a WIP and mostly so I can start building out the patch. Let me know if you want me to change things to fit a different design.